### PR TITLE
Convert containers to singularity images

### DIFF
--- a/.github/actions/build_container/action.yaml
+++ b/.github/actions/build_container/action.yaml
@@ -45,7 +45,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: create builder
+    - name: create container
       shell: bash
       run: |-
         echo "Building container in ${{ inputs.BUILD_PATH }}"

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -1,0 +1,3 @@
+[
+  "neurodamus-neocortex"
+]

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -1,3 +1,10 @@
 [
-  "neurodamus-neocortex"
+  "appositionizer",
+  "brain-indexer",
+  "connectome-manipulator",
+  "functionalizer",
+  "neurodamus-hippocampus",
+  "neurodamus-neocortex",
+  "neurodamus-thalamus",
+  "system-benchmarks"
 ]

--- a/.github/workflows/no_build_warning.yaml
+++ b/.github/workflows/no_build_warning.yaml
@@ -13,5 +13,6 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |-
-            Builds are only triggered when a label 'build' is added to the pull request, and only upon adding the label.
+            Builds are only triggered when a certain label is added to the pull request, and only upon adding the label.
             If you want to trigger another build, remove the label and add it again.
+            Add the label `build-with-base` if you want to build the runtime and builder containers in addition to the spacktainers, add the label `build` to build just the spacktainers.

--- a/.github/workflows/no_build_warning.yaml
+++ b/.github/workflows/no_build_warning.yaml
@@ -13,6 +13,5 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |-
-            Builds are only triggered when a certain label is added to the pull request, and only upon adding the label.
-            If you want to trigger another build, remove the label and add it again.
+            Builds are only triggered on pull requests which have either the `build` or the `build-with-base` label.
             Add the label `build-with-base` if you want to build the runtime and builder containers in addition to the spacktainers, add the label `build` to build just the spacktainers.

--- a/.github/workflows/no_build_warning.yaml
+++ b/.github/workflows/no_build_warning.yaml
@@ -1,0 +1,17 @@
+---
+name: Notify the user there is no automatic build
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  notify-user:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Notify user
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |-
+            Builds are only triggered when a label 'build' is added to the pull request, and only upon adding the label.
+            If you want to trigger another build, remove the label and add it again.

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -4,6 +4,18 @@ on:
   pull_request:
     types: [labeled]
 jobs:
+  matrix:
+    if: ${{ github.event.label.name == 'build' }}
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: clone repo
+        uses: actions/checkout@v4
+      - id: set-matrix
+        run: |-
+          SPACKTAINERS=$(echo $(cat .github/workflows/matrix.json) | sed 's/ //g')
+          echo "matrix=${SPACKTAINERS}" >> "${GITHUB_OUTPUT}"
   builder-container-job:
     if: ${{ github.event.label.name == 'build' }}
     environment: sandbox-hpc
@@ -73,21 +85,11 @@ jobs:
     environment: sandbox-hpc
     strategy:
       matrix:
-        spacktainer:
-          - appositionizer
-          - brain-indexer
-          # - brayns
-          - connectome-manipulator
-          - functionalizer
-          # - multiscale-run
-          - neurodamus-hippocampus
-          - neurodamus-neocortex
-          - neurodamus-thalamus
-          - system-benchmarks
+        spacktainer: ${{ fromJson(needs.matrix.outputs.matrix) }}
     runs-on:
       - codebuild-spacktainers-tf-${{ github.run_id }}-${{ github.run_attempt }}
     continue-on-error: true
-    needs: [builder-container-job, runtime-container-job]
+    needs: [builder-container-job, runtime-container-job, matrix]
     steps:
       - name: clone repo
         uses: actions/checkout@v4
@@ -133,20 +135,10 @@ jobs:
     if: ${{ github.event.label.name == 'build' }}
     environment: sandbox-hpc
     runs-on: ubuntu-latest
-    needs: [spacktainer-build-job]
+    needs: [spacktainer-build-job, matrix]
     strategy:
       matrix:
-        spacktainer:
-          - appositionizer
-          - brain-indexer
-          # - brayns
-          - connectome-manipulator
-          - functionalizer
-          # - multiscale-run
-          - neurodamus-hippocampus
-          - neurodamus-neocortex
-          - neurodamus-thalamus
-          - system-benchmarks
+        spacktainer: ${{ fromJson(needs.matrix.outputs.matrix) }}
     steps:
       - name: Install singularity
         run: |-

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   builder-container-job:
     if: ${{ github.event.label_name == 'build' }}
+    environment: sandbox-hpc
     runs-on:
       - codebuild-spacktainers-tf-${{ github.run_id }}-${{ github.run_attempt }}
       - instance-size:small
@@ -37,6 +38,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   runtime-container-job:
     if: ${{ github.event.label_name == 'build' }}
+    environment: sandbox-hpc
     runs-on:
       - codebuild-spacktainers-tf-${{ github.run_id }}-${{ github.run_attempt }}
       - instance-size:small
@@ -68,6 +70,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   spacktainer-build-job:
     if: ${{ github.event.label_name == 'build' }}
+    environment: sandbox-hpc
     strategy:
       matrix:
         spacktainer:
@@ -128,6 +131,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   convert-to-singularity:
     if: ${{ github.event.label_name == 'build' }}
+    environment: sandbox-hpc
     runs-on: ubuntu-latest
     needs: [spacktainer-build-job]
     strategy:
@@ -170,8 +174,8 @@ jobs:
         with:
           command: cp
           source: ./${{ matrix.spacktainer }}.sif
-          destination: s3://${{ secrets.S3_BUCKET }}/${{ vars.S3_CONTAINER_ROOT }}/${{
-            matrix.spacktainer }}.sif
+          destination: s3://${{ secrets.S3_SINGULARITY_BUCKET }}/${{ vars.S3_CONTAINER_ROOT
+            }}/${{ matrix.spacktainer }}.sif
           aws_access_key_id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
           aws_region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -135,7 +135,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   convert-to-singularity:
-    if: ${{ always() && needs.spacktainer-build-job.result == 'success' && contains(github.event.pull_request.labels.*.name, 'build') || contains(github.event.pull_request.labels.*.name, 'build-with-base') }}
+    if: ${{ always() && needs.spacktainer-build-job.result == 'success' && (contains(github.event.pull_request.labels.*.name, 'build') || contains(github.event.pull_request.labels.*.name, 'build-with-base')) }}
     environment: sandbox-hpc
     runs-on: ubuntu-latest
     needs: [spacktainer-build-job, matrix]

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -84,7 +84,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   spacktainer-build-job:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'build') && ! failure() && ! cancelled() }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'build') || contains(github.event.pull_request.labels.*.name, 'build-with-base') && ! failure() && ! cancelled() }}
     environment: sandbox-hpc
     strategy:
       matrix:
@@ -135,7 +135,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   convert-to-singularity:
-    if: ${{ always() && needs.spacktainer-build-job.result == 'success' && contains(github.event.pull_request.labels.*.name, 'build') }}
+    if: ${{ always() && needs.spacktainer-build-job.result == 'success' && contains(github.event.pull_request.labels.*.name, 'build') || contains(github.event.pull_request.labels.*.name, 'build-with-base') }}
     environment: sandbox-hpc
     runs-on: ubuntu-latest
     needs: [spacktainer-build-job, matrix]

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -149,7 +149,7 @@ jobs:
           sudo apt-get install -y singularity-container
           singularity --version
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credential@v4
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
           aws-secret-access-key-id: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -113,9 +113,7 @@ jobs:
             --label org.opencontainers.image.authors="$GITHUB_TRIGGERING_ACTOR" --label
             org.opencontainers.image.url="https://github.com/${GITHUB_REPOSITORY}"
             --label org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}"
-            --label ch.epfl.bbpgitlab.ci-pipeline-url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-            --label ch.epfl.bbpgitlab.ci-commit-branch="$GITHUB_REF_NAME" --build-arg
-            SPACK_BRANCH=develop --build-arg CACHE_BUCKET=${{ secrets.AWS_CACHE_BUCKET }}
+            --build-arg SPACK_BRANCH=develop --build-arg CACHE_BUCKET=${{ secrets.AWS_CACHE_BUCKET }}
             --build-arg MIRROR_AUTH_ARG="\"--s3-access-key-id='${{ secrets.AWS_CACHE_ACCESS_KEY_ID }}
             --s3-access-key-secret=${{ secrets.AWS_CACHE_SECRET_ACCESS_KEY }}'\""
           # ' --label org.opencontainers.image.created="$CI_JOB_STARTED_AT"'
@@ -123,3 +121,51 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
+  convert-to-singularity:
+    runs-on: ubuntu-latest
+    needs: [spacktainer-build-job]
+    strategy:
+      matrix:
+        spacktainer:
+          - appositionizer
+          - brain-indexer
+          # - brayns
+          - connectome-manipulator
+          - functionalizer
+          # - multiscale-run
+          - neurodamus-hippocampus
+          - neurodamus-neocortex
+          - neurodamus-thalamus
+          - system-benchmarks
+    steps:
+      - name: Install singularity
+        run: |-
+          sudo wget -O- http://neuro.debian.net/lists/xenial.us-ca.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
+          sudo apt-key adv --recv-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9
+          sudo apt-get update
+          sudo apt-get install -y build-essentials libssl-dev uuid-dev libgpgme11-dev squashfs-tools libseccomp-dev pkg-config
+          sudo apt-get install -y singularity-container
+          singularity --version
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credential@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key-id: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Authenticate with ECR
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Convert container
+        run: |-
+          export SINGULARITY_DOCKER_USERNAME=${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
+          export SINGULARITY_DOCKER_PASSWORD=${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
+          singularity pull --no-https "${{ matrix.spacktainer }}.sif" "docker://${{ secrets.AWS_ECR_URL }}/spacktainers/${{ matrix.spacktainer }}:latest"
+      - name: Drop container in S3 bucket
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: ./${{ matrix.spacktainer }}.sif
+          destination: s3://${{ secrets.S3_BUCKET }}/${{ vars.S3_CONTAINER_ROOT }}/${{
+            matrix.spacktainer }}.sif
+          aws_access_key_id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
+          aws_region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -149,7 +149,7 @@ jobs:
           sudo cat /etc/apt/sources.list.d/neurodebian.sources.list
           sudo wget -O /etc/apt/trusted.gpg.d/neurodebian.asc "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xA5D32F012649A5A9"
           sudo apt-get update
-          sudo apt-get install -y build-essentials libssl-dev uuid-dev libgpgme11-dev squashfs-tools libseccomp-dev pkg-config
+          sudo apt-get install -y build-essential libssl-dev uuid-dev libgpgme11-dev squashfs-tools libseccomp-dev pkg-config
           sudo apt-get install -y singularity-container
           singularity --version
       - name: Configure AWS credentials

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -152,18 +152,18 @@ jobs:
           sudo apt-get install -y build-essential libssl-dev uuid-dev libgpgme11-dev squashfs-tools libseccomp-dev pkg-config
           sudo apt-get install -y singularity-container
           singularity --version
+      - name: Install awscli
+        uses: unfor19/install-aws-cli-action@v1
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_REGION }}
-      - name: Authenticate with ECR
-        uses: aws-actions/amazon-ecr-login@v2
       - name: Convert container
         run: |-
-          export SINGULARITY_DOCKER_USERNAME=${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
-          export SINGULARITY_DOCKER_PASSWORD=${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
+          export SINGULARITY_DOCKER_USERNAME=AWS
+          export SINGULARITY_DOCKER_PASSWORD=$(aws ecr get-login-password)
           singularity pull --no-https "${{ matrix.spacktainer }}.sif" "docker://${{ secrets.AWS_ECR_URL }}/spacktainers/${{ matrix.spacktainer }}:latest"
       - name: Drop container in S3 bucket
         uses: keithweaver/aws-s3-github-action@v1.0.0

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -45,7 +45,7 @@ jobs:
             --label org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}"
             --label ch.epfl.bbpgitlab.ci-pipeline-url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
             --label ch.epfl.bbpgitlab.ci-commit-branch="$GITHUB_REF_NAME" --build-arg
-            SPACK_BRANCH=develop
+            SPACK_BRANCH=114bd5744f6a0e4d423ae902e2b75c9fb00bc8e9
          # ' --label org.opencontainers.image.created="$CI_JOB_STARTED_AT"'
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -77,7 +77,7 @@ jobs:
             --label org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}"
             --label ch.epfl.bbpgitlab.ci-pipeline-url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
             --label ch.epfl.bbpgitlab.ci-commit-branch="$GITHUB_REF_NAME" --build-arg
-            SPACK_BRANCH=develop
+            SPACK_BRANCH=114bd5744f6a0e4d423ae902e2b75c9fb00bc8e9
          # ' --label org.opencontainers.image.created="$CI_JOB_STARTED_AT"'
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -126,8 +126,8 @@ jobs:
             --label org.opencontainers.image.authors="$GITHUB_TRIGGERING_ACTOR" --label
             org.opencontainers.image.url="https://github.com/${GITHUB_REPOSITORY}"
             --label org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}"
-            --build-arg SPACK_BRANCH=develop --build-arg CACHE_BUCKET=${{ secrets.AWS_CACHE_BUCKET }}
-            --build-arg MIRROR_AUTH_ARG="\"--s3-access-key-id='${{ secrets.AWS_CACHE_ACCESS_KEY_ID }}
+            --build-arg SPACK_BRANCH=114bd5744f6a0e4d423ae902e2b75c9fb00bc8e9 --build-arg
+            CACHE_BUCKET=${{ secrets.AWS_CACHE_BUCKET }} --build-arg MIRROR_AUTH_ARG="\"--s3-access-key-id='${{ secrets.AWS_CACHE_ACCESS_KEY_ID }}
             --s3-access-key-secret=${{ secrets.AWS_CACHE_SECRET_ACCESS_KEY }}'\""
           # ' --label org.opencontainers.image.created="$CI_JOB_STARTED_AT"'
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -132,7 +132,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   convert-to-singularity:
-    if: ${{ github.event.label.name == 'build' }}
+    if: ${{ contains(github.event.label.name, 'build') }}
     environment: sandbox-hpc
     runs-on: ubuntu-latest
     needs: [spacktainer-build-job, matrix]

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -170,7 +170,7 @@ jobs:
         with:
           command: cp
           source: ./${{ matrix.spacktainer }}.sif
-          destination: s3://${{ secrets.S3_SINGULARITY_BUCKET }}/${{ vars.S3_CONTAINER_ROOT
+          destination: s3://${{ secrets.S3_SINGULARITY_BUCKET }}/${{ secrets.S3_CONTAINER_ROOT
             }}/${{ matrix.spacktainer }}.sif
           aws_access_key_id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -17,7 +17,7 @@ jobs:
           SPACKTAINERS=$(echo $(cat .github/workflows/matrix.json) | sed 's/ //g')
           echo "matrix=${SPACKTAINERS}" >> "${GITHUB_OUTPUT}"
   builder-container-job:
-    if: ${{ github.event.label.name == 'build' }}
+    if: ${{ github.event.label.name == 'build-with-base' }}
     environment: sandbox-hpc
     runs-on:
       - codebuild-spacktainers-tf-${{ github.run_id }}-${{ github.run_attempt }}
@@ -49,7 +49,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   runtime-container-job:
-    if: ${{ github.event.label.name == 'build' }}
+    if: ${{ github.event.label.name == 'build-with-base' }}
     environment: sandbox-hpc
     runs-on:
       - codebuild-spacktainers-tf-${{ github.run_id }}-${{ github.run_attempt }}
@@ -81,7 +81,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   spacktainer-build-job:
-    if: ${{ github.event.label.name == 'build' }}
+    if: ${{ contains(github.event.label.name, 'build') }}
     environment: sandbox-hpc
     strategy:
       matrix:

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -1,8 +1,11 @@
 ---
 name: Build Spacktainers
-on: [push]
+on:
+  pull_request:
+    types: [labeled]
 jobs:
   builder-container-job:
+    if: ${{ github.event.label_name == 'build' }}
     runs-on:
       - codebuild-spacktainers-tf-${{ github.run_id }}-${{ github.run_attempt }}
       - instance-size:small
@@ -33,6 +36,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   runtime-container-job:
+    if: ${{ github.event.label_name == 'build' }}
     runs-on:
       - codebuild-spacktainers-tf-${{ github.run_id }}-${{ github.run_attempt }}
       - instance-size:small
@@ -63,6 +67,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   spacktainer-build-job:
+    if: ${{ github.event.label_name == 'build' }}
     strategy:
       matrix:
         spacktainer:
@@ -122,6 +127,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   convert-to-singularity:
+    if: ${{ github.event.label_name == 'build' }}
     runs-on: ubuntu-latest
     needs: [spacktainer-build-job]
     strategy:

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -2,10 +2,10 @@
 name: Build Spacktainers
 on:
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, labeled, synchronize, edited]
 jobs:
   matrix:
-    if: ${{ github.event.label.name == 'build' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'build') }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -17,7 +17,7 @@ jobs:
           SPACKTAINERS=$(echo $(cat .github/workflows/matrix.json) | sed 's/ //g')
           echo "matrix=${SPACKTAINERS}" >> "${GITHUB_OUTPUT}"
   builder-container-job:
-    if: ${{ github.event.label.name == 'build-with-base' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'build-with-base') }}
     environment: sandbox-hpc
     runs-on:
       - codebuild-spacktainers-tf-${{ github.run_id }}-${{ github.run_attempt }}
@@ -49,7 +49,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   runtime-container-job:
-    if: ${{ github.event.label.name == 'build-with-base' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'build-with-base') }}
     environment: sandbox-hpc
     runs-on:
       - codebuild-spacktainers-tf-${{ github.run_id }}-${{ github.run_attempt }}
@@ -81,7 +81,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   spacktainer-build-job:
-    if: ${{ contains(github.event.label.name, 'build') && ! failure() && ! cancelled() }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'build') && ! failure() && ! cancelled() }}
     environment: sandbox-hpc
     strategy:
       matrix:
@@ -132,7 +132,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   convert-to-singularity:
-    if: ${{ always() && needs.spacktainer-build-job.result == 'success' && contains(github.event.label.name, 'build') }}
+    if: ${{ always() && needs.spacktainer-build-job.result == 'success' && contains(github.event.pull_request.labels.*.name, 'build') }}
     environment: sandbox-hpc
     runs-on: ubuntu-latest
     needs: [spacktainer-build-job, matrix]

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -3,6 +3,9 @@ name: Build Spacktainers
 on:
   pull_request:
     types: [opened, reopened, labeled, synchronize, edited]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.base_ref }}
+  cancel-in-progress: false
 jobs:
   matrix:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'build') }}

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -5,7 +5,7 @@ on:
     types: [labeled]
 jobs:
   builder-container-job:
-    if: ${{ github.event.label_name == 'build' }}
+    if: ${{ github.event.label.name == 'build' }}
     environment: sandbox-hpc
     runs-on:
       - codebuild-spacktainers-tf-${{ github.run_id }}-${{ github.run_attempt }}
@@ -37,7 +37,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   runtime-container-job:
-    if: ${{ github.event.label_name == 'build' }}
+    if: ${{ github.event.label.name == 'build' }}
     environment: sandbox-hpc
     runs-on:
       - codebuild-spacktainers-tf-${{ github.run_id }}-${{ github.run_attempt }}
@@ -69,7 +69,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   spacktainer-build-job:
-    if: ${{ github.event.label_name == 'build' }}
+    if: ${{ github.event.label.name == 'build' }}
     environment: sandbox-hpc
     strategy:
       matrix:
@@ -130,7 +130,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   convert-to-singularity:
-    if: ${{ github.event.label_name == 'build' }}
+    if: ${{ github.event.label.name == 'build' }}
     environment: sandbox-hpc
     runs-on: ubuntu-latest
     needs: [spacktainer-build-job]

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   matrix:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'build') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'build') || contains(github.event.pull_request.labels.*.name, 'build-with-base') }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -156,7 +156,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
-          aws-secret-access-key-id: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_REGION }}
       - name: Authenticate with ECR
         uses: aws-actions/amazon-ecr-login@v2

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -132,7 +132,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   convert-to-singularity:
-    if: ${{ contains(github.event.label.name, 'build') }}
+    if: ${{ always() && needs.spacktainer-build-job.result == 'success' && contains(github.event.label.name, 'build') }}
     environment: sandbox-hpc
     runs-on: ubuntu-latest
     needs: [spacktainer-build-job, matrix]

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -143,7 +143,8 @@ jobs:
       - name: Install singularity
         run: |-
           sudo wget -O- http://neuro.debian.net/lists/xenial.us-ca.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
-          sudo apt-key adv --recv-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9
+          sudo cat /etc/apt/sources.list.d/neurodebian.sources.list
+          sudo wget -O /etc/apt/trusted.gpg.d/neurodebian.asc "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xA5D32F012649A5A9"
           sudo apt-get update
           sudo apt-get install -y build-essentials libssl-dev uuid-dev libgpgme11-dev squashfs-tools libseccomp-dev pkg-config
           sudo apt-get install -y singularity-container

--- a/.github/workflows/spacktainer.yaml
+++ b/.github/workflows/spacktainer.yaml
@@ -81,7 +81,7 @@ jobs:
           SPACK_DEPLOYMENT_KEY_PUB: ${{ secrets.SPACK_DEPLOYMENT_KEY_PUB }}
           SPACK_DEPLOYMENT_KEY_PRIVATE: ${{ secrets.SPACK_DEPLOYMENT_KEY_PRIVATE }}
   spacktainer-build-job:
-    if: ${{ contains(github.event.label.name, 'build') }}
+    if: ${{ contains(github.event.label.name, 'build') && ! failure() && ! cancelled() }}
     environment: sandbox-hpc
     strategy:
       matrix:

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -40,7 +40,7 @@ RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
 
 RUN cp $SPACK_ROOT/share/spack/docker/modules.yaml \
     $SPACK_ROOT/etc/spack/modules.yaml \
-    && rm -rf /root/*.* /run/nologin $SPACK_ROOT/.git
+    && rm -rf /root/*.* /run/nologin
 
 # [WORKAROUND]
 # https://superuser.com/questions/1241548/
@@ -126,13 +126,15 @@ ONBUILD COPY key spack_key
 ONBUILD RUN spack gpg trust ./spack_key.pub
 ONBUILD RUN spack gpg trust ./spack_key
 
+ONBUILD RUN pushd ${SPACK_ROOT} && git log && rm -rf $SPACK_ROOT/.git && popd
+
 # Install the software, remove unnecessary deps
 #
 # Unconditionally sets the view to /opt/view for the runtime container
 ONBUILD RUN spack env activate /opt/spack-environment; \
     spack config add view:/opt/view && \
     if [ "$(uname -m)" != "aarch64" ]; then \
-        spack config add packages:all:require:target=x86_64_v3; \
+    spack config add packages:all:require:target=x86_64_v3; \
     fi && \
     spack config add concretizer:targets:granularity:generic && \
     spack config blame concretizer && \

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -135,6 +135,7 @@ ONBUILD RUN spack env activate /opt/spack-environment; \
         spack config add packages:all:require:target=x86_64_v3; \
     fi && \
     spack config add concretizer:targets:granularity:generic && \
+    spack config blame concretizer && \
     spack concretize && \
     spack install --show-log-on-error --fail-fast && \
     spack gc -y

--- a/container_definitions/amd64/connectome-manipulator/spack.yaml
+++ b/container_definitions/amd64/connectome-manipulator/spack.yaml
@@ -1,12 +1,13 @@
+---
 spack:
-  specs:
-    - parquet-converters
-    - py-connectome-manipulator
+  specs: [parquet-converters, py-connectome-manipulator]
+  concretizer:
+    unify: when_possible
   packages:
     py-pandas:
-      require: "~performance"  # Otherwise pulls in numba that requires outdated LLVM
+      require: ~performance  # Otherwise pulls in numba that requires outdated LLVM
     py-numpy-quaternion:
-      require: "~numba~scipy"  # See above, get around Numba
+      require: ~numba~scipy  # See above, get around Numba
     all:
       providers:
         mpi: [mpich]


### PR DESCRIPTION
For now everything uses the sandbox-hpc AWS environment: CodeBuild for running the builds, ECR for hosting the docker images, and S3 for storing the singularity images.